### PR TITLE
Update afsctool.c for Sierra

### DIFF
--- a/afsctool.c
+++ b/afsctool.c
@@ -104,9 +104,10 @@ void compressFile(const char *inFile, struct stat *inFileInfo, long long int max
 	
 	if (statfs(inFile, &fsInfo) < 0)
 		return;
-	if (fsInfo.f_type != 17)
+	if (fsInfo.f_type != 17 && fsInfo.f_type != 23) {
+		printf("Expecting f_type of 17 or 23. f_type is %i.\n", fsInfo.f_type);
 		return;
-	
+	}
 	if (!S_ISREG(inFileInfo->st_mode))
 		return;
 	if ((inFileInfo->st_flags & UF_COMPRESSED) != 0)


### PR DESCRIPTION
Scanning back through XNU code on opensource.apple.com it seems like fs_type_num for HFS has always been 17.

In Sierra it is now 23.
